### PR TITLE
Update TrelliscopeJS slides link

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -62,7 +62,7 @@ Also see
 
 
 - [Ryan Hafen](http://ryanhafen.com), [@hafenstats](https://twitter.com/hafenstats),
-  [TrelliscopeJS](http://slides.com/hafen/deck-6#/)
+  [TrelliscopeJS](http://slides.com/hafen/trelliscopejs)
 
 - [Karthik Ram](http://inundata.org), [@_inundata](https://twitter.com/_inundata), [rOpenSci Packages Every Muggle Should Know](http://inundata.org/talks/rc17/#/)
 


### PR DESCRIPTION
Previous link was broken. 

I updated with new link obtained from Hafen twitter 
https://twitter.com/hafenstats/status/826478606603874304